### PR TITLE
Replace tabularx with tabulary for table layout

### DIFF
--- a/cumtthesis.cls
+++ b/cumtthesis.cls
@@ -672,6 +672,7 @@
 \RequirePackage{listings} % 代码块支持
 \RequirePackage{xpatch} % 补丁命令
 \RequirePackage{verbatim} % 注释
+\RequirePackage{tabulary} % 自动列宽
 
 % 矿大蓝 RGB:30,50,100 (#1e3264)
 \definecolor{cumtblue}{RGB}{30,50,100}
@@ -1575,11 +1576,11 @@
             \arrayrulecolor{black}
             {
                 \zihao{5}
-                \begin{tabularx}{15.05cm}{|>{\centering\arraybackslash}m{2.3cm}|>{\centering\arraybackslash}m{1.3cm}|>{\centering\arraybackslash}m{2.3cm}|>{\centering\arraybackslash}m{1.3cm}|X|}
-                    \hline
-                    {\bfseries 关键词$\bm \ast$} & {\bfseries 密级$\bm \ast$} & {\bfseries 中图分类号$\bm \ast$} & {\bfseries UDC} & {\bfseries 论文资助} \\ \hline
-                    {\@cnkeywords} & {\cumt@security@level} & {\cumt@clc} & {\cumt@udc} & {\cumt@funding}  \\ \hline
-                \end{tabularx}
+                \begin{tabulary}{15.05cm}{|C|>{\centering\arraybackslash}m{1.3cm}|>{\centering\arraybackslash}m{2.3cm}|>{\centering\arraybackslash}m{1.3cm}|C|}
+                \hline
+                {\bfseries 关键词$\bm \ast$} & {\bfseries 密级$\bm \ast$} & {\bfseries 中图分类号$\bm \ast$} & {\bfseries UDC} & {\bfseries 论文资助} \\ \hline
+                {\@cnkeywords} & {\cumt@security@level} & {\cumt@clc} & {\cumt@udc} & {\cumt@funding}  \\ \hline
+                \end{tabulary}
             }
             \vskip -1.4pt
             {


### PR DESCRIPTION
用tabulary包改变了先前tabularx固定论文数据集中“关键词”列宽的方案，改为“关键词”与“资助”均衡分配列宽，以减少换行行数，避免表格跨行。
保留其他地方的tabluarx方案。